### PR TITLE
fix: Improve production readiness of config settings

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -4,8 +4,8 @@ import os
 
 class Settings(BaseSettings):
     # API Settings
-    api_host: str = "0.0.0.0"
-    api_port: int = 8000
+    api_host: str = os.getenv("API_HOST", "127.0.0.1")  # Default to localhost for security
+    api_port: int = int(os.getenv("API_PORT", "8000"))
     
     # NVIDIA API Settings
     nvidia_api_key: Optional[str] = os.getenv("NVIDIA_API_KEY")
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     embedding_model: str = "all-MiniLM-L6-v2"
     
     # Redis Settings
-    redis_url: str = "redis://localhost:6379"
+    redis_url: str = os.getenv("REDIS_URL", "redis://127.0.0.1:6379")
     
     # Security
     secret_key: str = os.getenv("SECRET_KEY", "your-secret-key-here")


### PR DESCRIPTION
## Summary

This PR improves the production readiness of the backend configuration by fixing hardcoded localhost and 0.0.0.0 binding issues.

### Problem
The current configuration has several issues:
1. **API binding to 0.0.0.0** - Exposes the API on all network interfaces by default
2. **Hardcoded localhost** - Redis URL uses localhost which may not resolve in production
3. **Non-configurable values** - Port and host values are hardcoded

### Solution

Made configuration more production-ready:

1. **api_host**: Changed default from `0.0.0.0` to `127.0.0.1` for secure local access
   - Now configurable via `API_HOST` environment variable

2. **api_port**: Made configurable via `API_PORT` environment variable
   - Defaults to 8000, can be overridden

3. **redis_url**: Changed default from `redis://localhost:6379` to `redis://127.0.0.1:6379`
   - Now configurable via `REDIS_URL` environment variable

### Changes

- `backend/core/config.py`: Updated 3 configuration settings to use environment variables with secure defaults

### Fixes

**Fixes #2, #4, #5, #7** - All related localhost and 0.0.0.0 binding issues