### PR TITLE
fix: Improve API base URL configuration for production deployment

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -4,8 +4,8 @@ import os
 
 class Settings(BaseSettings):
     # API Settings
-    api_host: str = "0.0.0.0"
-    api_port: int = 8000
+    api_host: str = os.getenv("API_HOST", "127.0.0.1")  # Default to localhost for security
+    api_port: int = int(os.getenv("API_PORT", "8000"))
     
     # NVIDIA API Settings
     nvidia_api_key: Optional[str] = os.getenv("NVIDIA_API_KEY")
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     embedding_model: str = "all-MiniLM-L6-v2"
     
     # Redis Settings
-    redis_url: str = "redis://localhost:6379"
+    redis_url: str = os.getenv("REDIS_URL", "redis://127.0.0.1:6379")
     
     # Security
     secret_key: str = os.getenv("SECRET_KEY", "your-secret-key-here")

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,13 @@
 import { toast } from "sonner";
 
-const API_BASE_URL = "http://localhost:8000/api";
+// Get API base URL from environment or default to localhost for development
+const getApiBaseUrl = () => {
+  const envUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (envUrl) return envUrl;
+  return "http://localhost:8000/api";
+};
+
+const API_BASE_URL = getApiBaseUrl();
 
 export interface Agent {
   id: number;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,23 @@
 import { toast } from "sonner";
 
 // Get API base URL from environment or default to localhost for development
-const getApiBaseUrl = () => {
+// In production, this should always be set via NEXT_PUBLIC_API_BASE_URL
+const getApiBaseUrl = (): string => {
+  // Check for environment variable (works in both server and client)
   const envUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-  if (envUrl) return envUrl;
+  if (envUrl && envUrl.trim() !== "") {
+    // Ensure URL ends with /api
+    return envUrl.endsWith("/api") ? envUrl : `${envUrl}/api`;
+  }
+
+  // Development fallback with localhost
+  // Check if we're running on localhost
+  if (typeof window !== "undefined" && window.location.hostname === "localhost") {
+    return "http://localhost:8000/api";
+  }
+
+  // Production fallback - this should NOT happen if environment is configured correctly
+  console.warn("WARNING: Using localhost fallback for API_BASE_URL. Set NEXT_PUBLIC_API_BASE_URL in production!");
   return "http://localhost:8000/api";
 };
 


### PR DESCRIPTION
## Summary

Issue #7: Hardcoded localhost prevents production deployment

## Changes

- Enhanced getApiBaseUrl() with better validation
- Normalize URL format (ensure /api suffix)
- Add runtime detection for localhost vs production
- Add console warning when using localhost fallback in production
- More robust error handling for missing configuration

## Security Impact

- Medium: Application now properly configurable for production
- Provides clear warnings when misconfigured

## Usage

Set NEXT_PUBLIC_API_BASE_URL in production environment:
```bash
export NEXT_PUBLIC_API_BASE_URL="https://api.example.com"
```